### PR TITLE
🚀🐛 Switches to `peaceiris/gh-pages` for Deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,29 +11,31 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
     - uses: actions/checkout@v1
+
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: Configure Git identity
-      run: |
-        git config --global user.email "noreply@github.com"
-        git config --global user.name "GitHub"
+
     - name: npm ci
       run: |
         npm ci
       env:
         CI: true
+
     - name: npm run build-for-deploy
       run: |
         npm run build-for-deploy
       env:
         CI: true
-    - name: npm run deploy
-      run: |
-        npm run deploy
+
+    - name: Deploy
+      uses: docker://peaceiris/gh-pages:00a0fa7ee8bd33aee5389fcee5eed89934afedef04c894283de2da307a793f92 # v2.5.1
       env:
-        CI: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
+        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        PUBLISH_BRANCH: gh-pages
+        PUBLISH_DIR: ./public
+      with:
+        emptyCommits: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-starter-default",
+  "name": "brucificus-curriculum-vitae",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -5394,12 +5394,6 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
-    "email-addresses": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
-      "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==",
-      "dev": true
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -6488,35 +6482,6 @@
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.0",
         "trim-repeated": "^1.0.0"
-      }
-    },
-    "filenamify-url": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
-      "integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
-      "dev": true,
-      "requires": {
-        "filenamify": "^1.0.0",
-        "humanize-url": "^1.0.0"
-      },
-      "dependencies": {
-        "filename-reserved-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-          "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
-          "dev": true
-        },
-        "filenamify": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
-          "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
-          "dev": true,
-          "requires": {
-            "filename-reserved-regex": "^1.0.0",
-            "strip-outer": "^1.0.0",
-            "trim-repeated": "^1.0.0"
-          }
-        }
       }
     },
     "filesize": {
@@ -8673,75 +8638,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "gh-pages": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-2.1.1.tgz",
-      "integrity": "sha512-yNW2SFp9xGRP/8Sk2WXuLI/Gn92oOL4HBgudn6PsqAnuWT90Y1tozJoTfX1WdrDSW5Rb90kLVOf5mm9KJ/2fDw==",
-      "dev": true,
-      "requires": {
-        "async": "^2.6.1",
-        "commander": "^2.18.0",
-        "email-addresses": "^3.0.1",
-        "filenamify-url": "^1.0.0",
-        "fs-extra": "^7.0.0",
-        "globby": "^6.1.0",
-        "graceful-fs": "^4.1.11",
-        "rimraf": "^2.6.2"
-      },
-      "dependencies": {
-        "array-union": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-          "dev": true,
-          "requires": {
-            "array-uniq": "^1.0.1"
-          }
-        },
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
-    },
     "git-up": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
@@ -9487,49 +9383,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
-    },
-    "humanize-url": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
-      "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
-      "dev": true,
-      "requires": {
-        "normalize-url": "^1.0.0",
-        "strip-url-auth": "^1.0.0"
-      },
-      "dependencies": {
-        "normalize-url": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-          "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.0.1",
-            "prepend-http": "^1.0.0",
-            "query-string": "^4.1.0",
-            "sort-keys": "^1.0.0"
-          }
-        },
-        "query-string": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
-          }
-        },
-        "sort-keys": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-          "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-          "dev": true,
-          "requires": {
-            "is-plain-obj": "^1.0.0"
-          }
-        }
-      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -16214,12 +16067,6 @@
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
-    },
-    "strip-url-auth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
-      "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
-      "dev": true
     },
     "style-loader": {
       "version": "0.23.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@types/react-helmet": "^5.0.14",
     "@types/typography": "^0.16.3",
     "gatsby-plugin-typescript": "^2.1.18",
-    "gh-pages": "^2.1.1",
     "prettier": "^1.19.1",
     "sass": "^1.23.6"
   },

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "start": "npm run develop",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \"",
-    "build-for-deploy": "gatsby build --prefix-paths",
-    "deploy": "gh-pages -d public -r https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/brucificus/curriculum-vitae.git -b gh-pages --dotfiles"
+    "build-for-deploy": "gatsby build --prefix-paths"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Due to a shortcoming of GitHub Actions[1], we are unable to use the in-built `GITHUB_TOKEN` secret in order to push to the `gh-pages` branch if we want it to in-turn trigger GitHub's internal process of publishing our changes. As such, we need to use a branch-pushing mechanism that uses a "Deploy" key such that it has full (GitHub-internal) permissions in order to trigger the downstream (internal) deployment process.

This switches us from using the [`gh-pages`](https://www.npmjs.com/package/gh-pages) NPM package to using the [`peaceiris/gh-pages`](https://github.com/peaceiris/actions-gh-pages) GitHub Action for these branch pushes, because the latter supports using the SSH key I've added as a secret to the repository to be used for deployments.

[1]: https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/true/page/2