### PR TITLE
🚀🐛 Switches to Tag-based Docker Image Reference

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         CI: true
 
     - name: Deploy
-      uses: docker://peaceiris/gh-pages:00a0fa7ee8bd33aee5389fcee5eed89934afedef04c894283de2da307a793f92 # v2.5.1
+      uses: docker://peaceiris/gh-pages:v2.5.1
       env:
         ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         PUBLISH_BRANCH: gh-pages


### PR DESCRIPTION
The deployment is failing[1] when it attempts to pull the docker image for the GitHub Pages task, so this switches to referencing the image by tag in order to hopefully fix it.

[1]: https://github.com/brucificus/curriculum-vitae/commit/95c4d36f0720bd6b1246a3e1f6e9ba3bb284c78d/checks?check_suite_id=315454763